### PR TITLE
FEM matrix loading bug fixes

### DIFF
--- a/examples/fiedler_tree/meson.build
+++ b/examples/fiedler_tree/meson.build
@@ -4,7 +4,7 @@ executable(
   dependencies : [butterfly_dep, m_dep]
 )
 
-foreach obj_file : [ 'dragon0.obj', 'dragon1.obj', 'dragon2.obj', 'dragon3.obj' ]
+foreach obj_file : [ 'dragon0.obj', 'dragon1.obj', 'dragon2.obj']
   fs.copyfile(obj_file, obj_file)
 endforeach
 

--- a/examples/lbo_MFEM/lbo_MFEM.cpp
+++ b/examples/lbo_MFEM/lbo_MFEM.cpp
@@ -163,6 +163,7 @@ int main(int argc, char *argv[])
    m->Assemble();
    m->Finalize();
 
+   // TODO: upcast indptr and indices to BfSize so they can be read in
    const SparseMatrix& A = a->SpMat();
    const int *A_indptr = A.GetI();
    const int *A_indices = A.GetJ();

--- a/examples/lbo_MFEM/lbo_MFEM.cpp
+++ b/examples/lbo_MFEM/lbo_MFEM.cpp
@@ -163,7 +163,8 @@ int main(int argc, char *argv[])
    m->Assemble();
    m->Finalize();
 
-   // TODO: upcast indptr and indices to BfSize so they can be read in
+   // TODO: upcast indptr and indices to BfSize so we can read them into bf_lbo
+   // TODO: GetI() includes index length(I), so it needs to be truncated by one
    const SparseMatrix& A = a->SpMat();
    const int *A_indptr = A.GetI();
    const int *A_indices = A.GetJ();

--- a/examples/lbo_MFEM/lbo_MFEM.cpp
+++ b/examples/lbo_MFEM/lbo_MFEM.cpp
@@ -173,23 +173,23 @@ int main(int argc, char *argv[])
    const int *M_indices = M.GetJ();
    const double *M_data = M.GetData();
 
-   fp = fopen("A_indptr.bin", "w");
+   fp = fopen("L_rowptr.bin", "w");
    fwrite(A_indptr, sizeof(int), A.NumRows() + 1, fp);
    fclose(fp);
 
-   fp = fopen("A_indices.bin", "w");
+   fp = fopen("L_colind.bin", "w");
    fwrite(A_indices, sizeof(int), A.NumNonZeroElems(), fp);
    fclose(fp);
 
-   fp = fopen("A_data.bin", "w");
+   fp = fopen("L_data.bin", "w");
    fwrite(A_data, sizeof(double), A.NumNonZeroElems(), fp);
    fclose(fp);
 
-   fp = fopen("M_indptr.bin", "w");
+   fp = fopen("M_rowptr.bin", "w");
    fwrite(M_indptr, sizeof(int), M.NumRows() + 1, fp);
    fclose(fp);
 
-   fp = fopen("M_indices.bin", "w");
+   fp = fopen("M_colind.bin", "w");
    fwrite(M_indices, sizeof(int), M.NumNonZeroElems(), fp);
    fclose(fp);
 

--- a/src/mat_csr_real.c
+++ b/src/mat_csr_real.c
@@ -370,8 +370,8 @@ BfMatCsrReal *bfMatCsrRealNewFromBinaryFiles(char const *rowptrPath, char const 
   BfRealArray *dataArray = bfRealArrayNewFromFile(dataPath);
   HANDLE_ERROR();
 
-  BfSize numRows = bfSizeArrayGetMaximum(colindArray);
-  BfSize numCols = bfSizeArrayGetSize(rowptrArray);
+  BfSize numCols = bfSizeArrayGetMaximum(colindArray) + 1;
+  BfSize numRows = bfSizeArrayGetSize(rowptrArray);
 
   BfMatCsrReal *matCsrReal = bfMatCsrRealNewFromArrays(
     numRows, numCols, rowptrArray, colindArray, dataArray, BF_POLICY_STEAL);


### PR DESCRIPTION
Bug fixes for various aspects of the FEM sparse matrix construction and loading processes. See comments in code.

I've resolved the problems with the MFEM sphere matrices (`Int32` instead of `Int64` index types, row pointers contain an extra element) by modifying the existing binary files in Julia. These "TODO" changes in `lbo_MFEM.cpp` are to avoid future issues.

The outstanding bug that I'm unable to resolve is that 
`BfMat *L = bfMatCsrRealToMat(bfMatCsrRealNewFromBinaryFiles(rowptrPath, colindPath, dataPath))` 
returns a `BfMat` that appears to be empty. 

In lldb I've checked that `bfMatCsrRealNewFromBinaryFiles(rowptrPath, colindPath, dataPath)` is now reading the binaries correctly, but something appears to be going wrong in the upcasting, or in the usage of `L` in `bf_lbo.c`. I don't understand the type system in this library well enough to resolve the issue.

My minimal test for which loading fails is:
`./bf_lbo --matPath=butterfly-LBO-models/sphere_discretizations/h/4/ --useOctree --tol=1e-3 --freqTreeDepth=2`