### PR TITLE
fix mesh loading bug

### DIFF
--- a/examples/covariance/Project.toml
+++ b/examples/covariance/Project.toml
@@ -11,3 +11,6 @@ Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[compat]
+MeshIO = "=0.4.11"

--- a/examples/covariance/plot_exact_cov_test.jl
+++ b/examples/covariance/plot_exact_cov_test.jl
@@ -8,7 +8,7 @@ println("Loading mesh...")
 
 mesh_file = ARGS[1]
 meshname  = split(split(mesh_file, "/")[end], ".")[1]
-_, mesh, vertices, n = load_mesh(mesh_file)
+gbmesh, mesh, vertices, n = load_mesh(mesh_file)
 
 ## load matrices
 println("Loading FEM matrices...")


### PR DESCRIPTION
There were some updates to the underlying Julia `MeshIO` package which were messing up mesh loading. But that is used only for my plotting scripts, so I simply capped the version of that package.

This should resolve #9 and #10.